### PR TITLE
Fix up recipe creation and persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ hs_err_pid*
 target
 .idea
 *.iml
+.classpath
+.project
+.factorypath
+.settings
+settings.json
+

--- a/src/main/java/org/dishorg/dishorg/Ingredient.java
+++ b/src/main/java/org/dishorg/dishorg/Ingredient.java
@@ -9,9 +9,6 @@ import javax.persistence.Id;
 @Data
 @Embeddable
 public class Ingredient {
-    private @Id
-    @GeneratedValue
-    Long id;
     private String name;
     private String unit;
     private double quantity;

--- a/src/main/java/org/dishorg/dishorg/IngredientRepository.java
+++ b/src/main/java/org/dishorg/dishorg/IngredientRepository.java
@@ -1,7 +1,0 @@
-package org.dishorg.dishorg;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface IngredientRepository  extends JpaRepository<Ingredient,Long> {
-
-}

--- a/src/main/java/org/dishorg/dishorg/Recipe.java
+++ b/src/main/java/org/dishorg/dishorg/Recipe.java
@@ -7,12 +7,12 @@ import java.util.List;
 
 @Data
 @Entity
-@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"name"}))
 public class Recipe {
-    private @Id
-    @GeneratedValue
-    Long id;
+    private @Id @GeneratedValue Long id;
+
+    @Column(unique = true)
     private String name;
+
     @ElementCollection
     private List<Ingredient> ingredients;
 

--- a/src/main/java/org/dishorg/dishorg/Recipe.java
+++ b/src/main/java/org/dishorg/dishorg/Recipe.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 @Data
 @Entity
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"name"}))
 public class Recipe {
     private @Id
     @GeneratedValue


### PR DESCRIPTION
* Remove IngredientRepository since Ingredient is an @Embeddable, not @Entity.
* Remove id attribute of Ingredient since it is an @Embeddable.
* Add a uniqueness constraint on the name of a recipe.
* Add various file patterns to .gitignore for files to exclude project files from VS Code and the like.